### PR TITLE
Find Chrome beyond fixed paths; add eval/screenshot/wait/navigate verbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,8 @@ python3 scripts/cdp-wait.py --file /tmp/events.jsonl \
   --method Page.loadEventFired --timeout 20                     # per event
 ```
 
+For a single event you expect *after* you act, `chrome-agent wait <Domain.event> --timeout N` needs no background stream at all — but it cannot match an event that fired before it subscribed, which is exactly what the file technique buys you.
+
 Needs only a backgrounded shell command and a file read. You lose the ability to work *while* events arrive, but you keep the precise wake — measured at 82 ms from navigation, against ~4.9 s wasted by a conservative `sleep 5`. It also catches events that fired *before* the wait started, which a bare `tail -f` silently drops.
 
 Full technique, pitfalls, and the reproducible proof: **[docs/event-driven-without-monitor.md](docs/event-driven-without-monitor.md)**.
@@ -183,7 +185,7 @@ Full technique, pitfalls, and the reproducible proof: **[docs/event-driven-witho
 Output is JSON on stdout. A one-shot prints the CDP method's **raw result object**, pretty-printed (shapes differ by method — check, don't assume). `launch`/`status` print structured JSON when stdout isn't a TTY. Errors go to **stderr** and exit non-zero, and are self-describing (an unknown instance lists the available ones; a CDP protocol error prints `CDP error <code>: <message>`).
 
 ```bash
-chrome-agent launch [--port PORT] [--headless] [--fingerprint profile.json] [--no-window-border]
+chrome-agent launch [--port PORT] [--headless] [--fingerprint profile.json] [--binary PATH] [--no-window-border]
 chrome-agent status [<instance>]
 chrome-agent attach <instance> [+Event ...] [--target SPEC] [--url SUBSTRING]
 chrome-agent stop <instance> [--target SPEC] [--url SUBSTRING]
@@ -191,13 +193,50 @@ chrome-agent help [<instance>] [Domain | Domain.method]
 chrome-agent cleanup
 chrome-agent --version
 chrome-agent <instance> Domain.method '{"param": "value"}'
+
+chrome-agent eval [<instance>] <expr | --file PATH | -> [--json]
+chrome-agent screenshot [<instance>] [-o FILE] [--full-page] [--selector CSS] [--format png|jpeg] [--quality N]
+chrome-agent wait [<instance>] <Domain.event ...> [--timeout SECS] [--contains SUBSTRING]
+chrome-agent navigate [<instance>] <URL> [--wait load|domcontentloaded|none] [--timeout SECS]
 ```
 
 - `launch` → `{"name","port","pid","browser_version"}`
 - `status` → `[{"name","port","alive","targets":[{"id","full_id","index","url","title"}]}]` — `index` is what `--target N` selects
 - `Page.navigate` → `{"frameId","loaderId","isDownload"}`
 - `Runtime.evaluate` (`returnByValue:true`) → `{"result":{"type":"string","value":"..."}}` — read **`result.value`** (the value sits under the `result` key)
-- `Page.captureScreenshot` → `{"data":"<base64 png>"}` — bytes are at `data`, **not** `result.data`; decode with `… | python3 -c "import sys,json,base64; open('/tmp/s.png','wb').write(base64.b64decode(json.load(sys.stdin)['data']))"` — then view `/tmp/s.png` to actually see the render.
+- `Page.captureScreenshot` → `{"data":"<base64 png>"}` — bytes are at `data`, **not** `result.data`. Prefer `chrome-agent screenshot -o /tmp/s.png`, which decodes and writes the file for you and prints its path; then view the file to actually see the render.
+
+## Four verbs that save you the plumbing
+
+`eval`, `screenshot`, `wait`, and `navigate` are thin wrappers over `Runtime.evaluate`, `Page.captureScreenshot`, event subscription, and `Page.navigate`. They exist because those four, expressed raw, cost you a quoting fight, a base64 decode, a `sleep`, and a blind guess about whether the page loaded. The raw forms still work and still reach everything.
+
+```bash
+# eval -- JS from a file or stdin, so no JSON-inside-shell quoting. Prints the
+# VALUE (string as-is, anything else as JSON); promises are awaited.
+chrome-agent eval 'document.title'
+chrome-agent eval --file probe.js                 # multi-line JS, no escaping
+echo 'document.readyState' | chrome-agent eval -
+chrome-agent eval 'bad(' --json                   # --json keeps the CDP envelope
+
+# screenshot -- decodes and writes the file, prints the path
+chrome-agent screenshot -o /tmp/page.png
+chrome-agent screenshot -o /tmp/all.png --full-page       # beyond the viewport
+chrome-agent screenshot -o /tmp/el.png --selector '#submit'  # one element
+
+# wait -- returns the instant the event lands; exits 1 on timeout
+chrome-agent wait Page.loadEventFired --timeout 15
+chrome-agent wait Network.responseReceived --contains example.com --timeout 20
+
+# navigate -- go, wait for the load, report the real HTTP status
+chrome-agent navigate https://example.com
+# {"url":"https://example.com/","status":200,"frameId":"...","loaderId":"...","loaded":true,"elapsedMs":93}
+```
+
+**`Page.navigate` alone cannot tell you a 404 from a 200** — its result is `{frameId, loaderId, isDownload}` either way, so a soft error page reads as success until you inspect the DOM. `navigate` waits for the document to finish and reports `status`, which is the check to make before you start scraping. `--wait none` returns at commit and reports `"loaded": null` (nothing was waited on); a load that never finishes exits 1 with `"loaded": false`. Chrome refusing the navigation outright (DNS failure, bad scheme) is an error, not a result.
+
+A page exception is an **error**, not a value: `eval` prints `Page error: ...` to stderr and exits 1, so a thrown error can't be mistaken for a result.
+
+**`wait` only sees events that fire after it subscribes.** It opens its own session, so anything that already happened is invisible to it — start it in the background *before* the action that triggers the event, or use the `attach`-to-a-file technique above when you need to catch events that may fire first.
 
 ## Targeting tabs
 
@@ -215,6 +254,7 @@ A one-shot against multiple tabs without a specifier is an error that lists them
 chrome-agent launch                       # auto port + name (from cwd); isolated profile under /tmp/chrome-agent
 chrome-agent launch --headless            # no window (no border, no desktop pinning)
 chrome-agent launch --fingerprint p.json  # spoof UA/viewport/lang/TZ via launch flags (also suppresses the marker)
+chrome-agent launch --binary /path/chrome  # explicit browser (also $CHROME_AGENT_BINARY)
 chrome-agent launch -- --some-chrome-flag # everything after -- passes through to Chrome
 chrome-agent status                       # all instances + their tabs
 chrome-agent stop mysite-01 [--target 2 | --url foo]   # whole browser, or one tab
@@ -229,6 +269,7 @@ Headed launches are marked (colored border + `🤖 <instance>` title prefix) so 
 
 ## Gotchas
 
+- **Browser discovery** checks the platform's well-known install paths first, then `$PATH`. If Chrome lives somewhere else (Chrome for Testing, a user-local install), point at it with `--binary PATH` or `$CHROME_AGENT_BINARY` — an override is authoritative, so a bad path errors rather than silently launching some other browser.
 - **Navigation kills context.** A pending `Runtime.evaluate` errors with "context destroyed" when the page navigates. Retry on the new page.
 - **One-shot latency** ~70 ms (process startup). For tight loops or event capture, prefer `attach` / a Python driver.
 - **Event isolation.** Each `attach` session sees only its own subscriptions.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ uv add chrome-agent
 
 Requires Google Chrome or Chromium installed on the system. Single runtime dependency (`websockets`). No Playwright, no browser downloads.
 
+The browser is found by checking the platform's well-known install paths first, then `$PATH`. For anything else -- Chrome for Testing, a user-local install, a second channel you want to pin -- name it explicitly:
+
+```bash
+chrome-agent launch --binary /opt/chrome-for-testing/chrome
+CHROME_AGENT_BINARY=/opt/chrome-for-testing/chrome chrome-agent launch
+```
+
+An override is authoritative: if the path is not executable the launch fails and names it, rather than silently falling back to a different browser than the one you asked for.
+
 ## Quick Start
 
 ```bash
@@ -110,13 +119,18 @@ An attach session **exits on its own once it has outlived its purpose** -- when 
 ## Operational Commands
 
 ```
-chrome-agent launch [--headless] [--fingerprint PATH] [--port PORT] [--no-window-border]
+chrome-agent launch [--headless] [--fingerprint PATH] [--port PORT] [--binary PATH] [--no-window-border]
 chrome-agent status [<instance>]
 chrome-agent attach <instance> [+Event ...] [--target SPEC] [--url SUBSTRING]
 chrome-agent stop <instance> [--target SPEC] [--url SUBSTRING]
 chrome-agent help [<instance>] [Domain | Domain.method]
 chrome-agent cleanup
 chrome-agent --version
+
+chrome-agent eval [<instance>] <expr | --file PATH | -> [--json]
+chrome-agent screenshot [<instance>] [-o FILE] [--full-page] [--selector CSS] [--format png|jpeg] [--quality N]
+chrome-agent wait [<instance>] <Domain.event ...> [--timeout SECS] [--contains SUBSTRING]
+chrome-agent navigate [<instance>] <URL> [--wait load|domcontentloaded|none] [--timeout SECS]
 ```
 
 | Command | Description |
@@ -128,10 +142,50 @@ chrome-agent --version
 | `help` | Query the browser's protocol schema. Lists domains, commands, events, parameters. |
 | `cleanup` | Remove stale instances (dead browsers) and their session directories. |
 | `--version` | Print the installed chrome-agent version (`-V` alias) and exit. |
+| `eval` | Run JavaScript and print the resulting value. Source comes from an argument, `--file`, or stdin (`-`), which sidesteps JSON-inside-shell quoting. Promises are awaited; a page exception exits 1. |
+| `screenshot` | Capture the page to a file -- base64 decoding included. `--full-page` captures beyond the viewport, `--selector` captures one element. |
+| `wait` | Block until a CDP event fires, then print it. Exits 1 on timeout. Replaces fixed `sleep`s in scripted flows. |
+| `navigate` | Navigate, wait for the document to load, and report the main document's HTTP status -- which raw `Page.navigate` never returns. |
 
 Instances are tracked in a registry at `/tmp/chrome-agent/registry.json`. A headed browser's instance is **automatically removed from the registry when its window is closed** (its session directory is cleaned up too), so `status` reflects what is actually running. Liveness is determined by **process identity plus port attribution**, not a bare PID-existence check: the recorded PID counts only if it is a live process of the launching user whose start time matches what was recorded at launch (so a recycled or namespace-local PID never masquerades as the browser), and a listening CDP port counts only if a process claiming that port with this instance's profile directory can be found -- so browsers started via wrapper/snap launchers (which fork the real browser into another process) are still reported correctly, while a port since claimed by a *different* browser is not mistaken for this one. A **transient connection drop does not retire a live instance**: a host suspend/resume severs the supervisor's CDP connection while Chrome keeps running, so the supervisor reconnects and keeps supervising; retirement happens only once the CDP port stops listening. `cleanup` removes any entries that remain (headless instances, or browsers that were killed abruptly).
 
 Two consequences worth knowing. **Launching from inside a PID-namespaced sandbox** (a container, bubblewrap, some agent-CLI sandboxes) records the sandbox's local PID in the shared registry; the identity check recognizes such an entry as stale once its browser is gone, instead of treating the aliased host PID as a live browser forever. **`stop` verifies its target before acting**: it never sends `Browser.close` to a port that is serving a different browser (it terminates the instance's own verified process instead, or just cleans up the stale entry), and its SIGTERM fallback only ever fires at a PID verified to be the instance's own browser process.
+
+## Convenience Verbs
+
+Three operations dominate agent use and are awkward as raw CDP calls, so each has a verb. They are wrappers, not a layer: the raw form still reaches every method, and nothing is validated against a bundled schema.
+
+```bash
+# JavaScript without the JSON-inside-shell quoting fight
+chrome-agent eval 'document.title'
+chrome-agent eval --file scrape.js          # multi-line JS, no escaping
+echo 'document.readyState' | chrome-agent eval -
+```
+
+`eval` prints the **value** -- a string as itself, anything else as JSON -- because `Runtime.evaluate`'s envelope (`result.result.value`) is almost never what the caller wants. Promises are awaited. `--json` returns the full response. A thrown page exception goes to stderr and exits 1, so an error can never be mistaken for a result.
+
+```bash
+# Screenshots land on disk, already decoded
+chrome-agent screenshot -o page.png
+chrome-agent screenshot -o full.png --full-page
+chrome-agent screenshot -o button.png --selector '#submit'
+```
+
+```bash
+# Wait for an event instead of guessing with sleep
+chrome-agent wait Page.loadEventFired --timeout 15
+chrome-agent wait Network.responseReceived --contains example.com
+```
+
+```bash
+# Navigate with a load barrier and a real status code
+chrome-agent navigate https://example.com
+# {"url":"https://example.com/","status":200,...,"loaded":true,"elapsedMs":93}
+```
+
+`Page.navigate` returns at commit time and its result carries no status, so a 404 or a bot-block page is indistinguishable from content until you inspect the DOM. `navigate` closes both gaps: it waits for `load` (or `domcontentloaded`, or nothing) and reports `status`. A navigation Chrome refuses outright -- DNS failure, bad scheme -- exits 1 rather than returning a result that looks fine.
+
+`wait` opens its own isolated session, so it matches only events that fire **after** it subscribes -- start it in the background before the action that triggers the event. To catch events that may fire first, background `attach` to a file and use [`scripts/cdp-wait.py`](scripts/cdp-wait.py) instead.
 
 ## Interacting with Elements
 

--- a/src/chrome_agent/cli.py
+++ b/src/chrome_agent/cli.py
@@ -14,7 +14,10 @@ import sys
 
 
 # Operational commands -- checked first during routing
-OPERATIONAL_COMMANDS = {"launch", "status", "attach", "help", "cleanup", "stop", "guide"}
+OPERATIONAL_COMMANDS = {
+    "launch", "status", "attach", "help", "cleanup", "stop", "guide",
+    "eval", "screenshot", "wait", "navigate",
+}
 
 
 def _extract_flags(argv: list[str]) -> tuple[list[str], str | None, str | None]:
@@ -67,13 +70,19 @@ def _print_static_usage() -> None:
     print("chrome-agent -- CLI for AI agents to control Chrome via CDP\n")
     print("Usage: chrome-agent <command> [args...]\n")
     print("Operational commands:")
-    print("  launch [--port PORT] [--fingerprint PATH] [--headless] [--no-window-border] [-- CHROME_ARGS]  Launch Chrome")
+    print("  launch [--port PORT] [--fingerprint PATH] [--headless] [--binary PATH] [--no-window-border] [-- CHROME_ARGS]  Launch Chrome")
     print("  status [<instance>]                                      List instances and targets")
     print("  attach <instance> [+Event ...] [--target SPEC] [--url SUB]  Attach for events")
     print("  help [<instance>] [Domain | Domain.method]               Protocol discovery")
     print("  stop <instance>                                            Stop a browser gracefully")
     print("  cleanup                                                   Remove stale instances")
     print("  guide [--path]                                            Print this tool's agent guide")
+    print()
+    print("Page convenience commands (thin wrappers over CDP):")
+    print("  eval [<instance>] <expr | --file PATH | -> [--json]      Run JS, print the value")
+    print("  screenshot [<instance>] [-o FILE] [--full-page] [--selector CSS] [--format png|jpeg] [--quality N]  Save an image")
+    print("  wait [<instance>] <Event ...> [--timeout SECS] [--contains SUB]  Block until an event fires")
+    print("  navigate [<instance>] <URL> [--wait load|domcontentloaded|none] [--timeout SECS]  Go, wait, report status")
     print()
     print("  --version, -V                                            Show version and exit")
     print()
@@ -87,6 +96,10 @@ def _print_static_usage() -> None:
     print("  chrome-agent attach mysite-01 +Page.loadEventFired")
     print("  chrome-agent mysite-01 Page.navigate '{\"url\": \"https://example.com\"}'")
     print("  chrome-agent help Page.navigate")
+    print("  chrome-agent eval --file probe.js")
+    print("  chrome-agent screenshot -o page.png --full-page")
+    print("  chrome-agent wait Page.loadEventFired --timeout 15")
+    print("  chrome-agent navigate https://example.com")
 
 
 async def _run_launch(args: list[str]) -> None:
@@ -97,6 +110,7 @@ async def _run_launch(args: list[str]) -> None:
     headless = False
     port_override = None
     window_border = True
+    binary = None
     extra_args = []
     i = 0
     while i < len(args):
@@ -110,6 +124,9 @@ async def _run_launch(args: list[str]) -> None:
         elif args[i] == "--headless":
             headless = True
             i += 1
+        elif args[i] == "--binary" and i + 1 < len(args):
+            binary = args[i + 1]
+            i += 2
         elif args[i] == "--no-window-border":
             window_border = False
             i += 1
@@ -131,6 +148,7 @@ async def _run_launch(args: list[str]) -> None:
             headless=headless,
             extra_args=extra_args,
             window_border=window_border,
+            binary=binary,
         )
     except (BrowserNotFoundError, RuntimeError, TimeoutError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -350,31 +368,10 @@ async def _run_cdp_one_shot(
 ) -> None:
     """Send a single CDP command via browser-level WS + Target.attachToTarget."""
     from .attach import AmbiguousTargetError, TargetNotFoundError
-    from .cdp_client import CDPClient, get_ws_url
-    from .errors import CDPError
+    from .errors import CDPError, NoPageError
+    from .page_ops import attached_page_session
 
-    # Resolve instance
-    if instance_name is not None:
-        from .registry import InstanceNotFoundError, lookup
-        try:
-            info = lookup(instance_name=instance_name)
-        except InstanceNotFoundError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            sys.exit(1)
-        port = info.port
-    else:
-        # Default instance resolution: auto-select single live instance
-        from .registry import enumerate_instances
-        instances = enumerate_instances()
-        live = [i for i in instances if i.alive]
-        if len(live) == 0:
-            print("Error: no instances registered. Launch one with: chrome-agent launch", file=sys.stderr)
-            sys.exit(1)
-        elif len(live) > 1:
-            names = ", ".join(i.name for i in live)
-            print(f"Error: multiple instances running. Specify one: {names}", file=sys.stderr)
-            sys.exit(1)
-        port = live[0].port
+    port = _resolve_port_or_exit(instance_name=instance_name)
 
     # Parse params
     params = None
@@ -388,74 +385,334 @@ async def _run_cdp_one_shot(
             print("Error: parameters must be a JSON object", file=sys.stderr)
             sys.exit(1)
 
-    # Connect to browser-level WebSocket
     try:
-        browser_ws_url = get_ws_url(port=port, target_type="browser")
-    except (ConnectionError, RuntimeError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        sys.exit(1)
-
-    try:
-        async with CDPClient(ws_url=browser_ws_url) as cdp:
-            # Resolve target
-            targets_result = await cdp.send(method="Target.getTargets")
-            page_targets = sorted(
-                (t for t in targets_result.get("targetInfos", [])
-                 if t.get("type") == "page"),
-                key=lambda t: t.get("targetId", ""),
+        async with attached_page_session(
+            port=port, target_spec=target_spec, url_spec=url_spec
+        ) as (cdp, session_id):
+            result = await cdp.send(
+                method=method,
+                params=params,
+                session_id=session_id,
             )
-
-            if not page_targets:
-                print("Error: no page targets in browser", file=sys.stderr)
-                sys.exit(1)
-
-            from .attach import resolve_target
-            target_by = None
-            spec = None
-            if target_spec is not None:
-                spec = target_spec
-                target_by = "index" if target_spec.isdigit() else "id"
-            elif url_spec is not None:
-                spec = url_spec
-                target_by = "url"
-
-            target_id = resolve_target(
-                page_targets=page_targets,
-                target_spec=spec,
-                target_by=target_by,
-            )
-
-            # Create isolated session
-            session_result = await cdp.send(
-                method="Target.attachToTarget",
-                params={"targetId": target_id, "flatten": True},
-            )
-            session_id = session_result["sessionId"]
-
-            try:
-                result = await cdp.send(
-                    method=method,
-                    params=params,
-                    session_id=session_id,
-                )
-                print(json.dumps(result, indent=2))
-            finally:
-                try:
-                    await cdp.send(
-                        method="Target.detachFromTarget",
-                        params={"sessionId": session_id},
-                    )
-                except Exception:
-                    pass
-
-    except (AmbiguousTargetError, TargetNotFoundError) as exc:
+            print(json.dumps(result, indent=2))
+    except (AmbiguousTargetError, TargetNotFoundError, NoPageError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
     except CDPError as exc:
         print(f"CDP error {exc.code}: {exc.message}", file=sys.stderr)
         sys.exit(1)
-    except ConnectionError as exc:
+    except (ConnectionError, RuntimeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _resolve_port_or_exit(instance_name: str | None) -> int:
+    """Resolve an instance to a port, or exit 1 with the reason."""
+    from .page_ops import (
+        AmbiguousInstanceError,
+        InstanceNotFoundError,
+        NoLiveInstanceError,
+        resolve_port,
+    )
+
+    try:
+        return resolve_port(instance_name=instance_name)
+    except (InstanceNotFoundError, NoLiveInstanceError, AmbiguousInstanceError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _split_instance(args: list[str]) -> tuple[str | None, list[str]]:
+    """Peel an optional leading instance name off a verb's arguments.
+
+    A leading token only counts as an instance when the registry knows it, so
+    `eval document.title` and `eval mysite-01 document.title` both work and a
+    typo'd instance name surfaces as a bad expression rather than silently
+    running against the wrong browser.
+    """
+    if not args or args[0].startswith("-"):
+        return None, args
+
+    from .registry import enumerate_instances
+
+    if args[0] in {i.name for i in enumerate_instances()}:
+        return args[0], args[1:]
+    return None, args
+
+
+async def _run_eval(args: list[str], target_spec: str | None, url_spec: str | None) -> None:
+    """Evaluate JavaScript in a page and print the resulting value."""
+    from .errors import CDPError, NoPageError
+    from .page_ops import EvaluationError, run_eval
+
+    instance_name, rest = _split_instance(args=args)
+
+    raw_json = False
+    source_path = None
+    expression = None
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--json":
+            raw_json = True
+            i += 1
+        elif rest[i] == "--file" and i + 1 < len(rest):
+            source_path = rest[i + 1]
+            i += 2
+        elif rest[i] == "-":
+            source_path = "-"
+            i += 1
+        elif expression is None and not rest[i].startswith("--"):
+            expression = rest[i]
+            i += 1
+        else:
+            print(f"Error: unknown eval option: {rest[i]}", file=sys.stderr)
+            sys.exit(1)
+
+    if source_path is not None:
+        if expression is not None:
+            print("Error: give an expression or --file, not both", file=sys.stderr)
+            sys.exit(1)
+        if source_path == "-":
+            expression = sys.stdin.read()
+        else:
+            try:
+                with open(source_path, encoding="utf-8") as handle:
+                    expression = handle.read()
+            except OSError as exc:
+                print(f"Error: cannot read {source_path}: {exc}", file=sys.stderr)
+                sys.exit(1)
+
+    if not expression or not expression.strip():
+        print("Error: nothing to evaluate", file=sys.stderr)
+        print("Usage: chrome-agent eval [<instance>] <expr | --file PATH | ->", file=sys.stderr)
+        sys.exit(1)
+
+    port = _resolve_port_or_exit(instance_name=instance_name)
+
+    from .attach import AmbiguousTargetError, TargetNotFoundError
+    try:
+        print(await run_eval(
+            expression=expression,
+            port=port,
+            target_spec=target_spec,
+            url_spec=url_spec,
+            raw_json=raw_json,
+        ))
+    except EvaluationError as exc:
+        print(f"Page error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except CDPError as exc:
+        print(f"CDP error {exc.code}: {exc.message}", file=sys.stderr)
+        sys.exit(1)
+    except (AmbiguousTargetError, TargetNotFoundError, NoPageError, ConnectionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+async def _run_screenshot(args: list[str], target_spec: str | None, url_spec: str | None) -> None:
+    """Capture a page (or one element) to an image file."""
+    from .errors import CDPError, NoPageError
+    from .page_ops import EvaluationError, run_screenshot
+
+    instance_name, rest = _split_instance(args=args)
+
+    output_path = None
+    image_format = "png"
+    quality = None
+    full_page = False
+    selector = None
+    i = 0
+    while i < len(rest):
+        if rest[i] in ("-o", "--output") and i + 1 < len(rest):
+            output_path = rest[i + 1]
+            i += 2
+        elif rest[i] == "--full-page":
+            full_page = True
+            i += 1
+        elif rest[i] == "--selector" and i + 1 < len(rest):
+            selector = rest[i + 1]
+            i += 2
+        elif rest[i] == "--format" and i + 1 < len(rest):
+            image_format = rest[i + 1]
+            i += 2
+        elif rest[i] == "--quality" and i + 1 < len(rest):
+            try:
+                quality = int(rest[i + 1])
+            except ValueError:
+                print(f"Error: invalid quality: {rest[i + 1]}", file=sys.stderr)
+                sys.exit(1)
+            i += 2
+        else:
+            print(f"Error: unknown screenshot option: {rest[i]}", file=sys.stderr)
+            sys.exit(1)
+
+    if image_format not in ("png", "jpeg", "webp"):
+        print(f"Error: unsupported format: {image_format}", file=sys.stderr)
+        sys.exit(1)
+    if full_page and selector is not None:
+        print("Error: --full-page and --selector are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+    if output_path is None:
+        output_path = f"screenshot.{image_format}"
+
+    port = _resolve_port_or_exit(instance_name=instance_name)
+
+    from .attach import AmbiguousTargetError, TargetNotFoundError
+    try:
+        path, size = await run_screenshot(
+            port=port,
+            output_path=output_path,
+            image_format=image_format,
+            quality=quality,
+            full_page=full_page,
+            selector=selector,
+            target_spec=target_spec,
+            url_spec=url_spec,
+        )
+    except EvaluationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except CDPError as exc:
+        print(f"CDP error {exc.code}: {exc.message}", file=sys.stderr)
+        sys.exit(1)
+    except (AmbiguousTargetError, TargetNotFoundError, NoPageError, ConnectionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Error: cannot write {output_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if sys.stdout.isatty():
+        print(f"Saved {size} bytes to {path}")
+    else:
+        print(path)
+
+
+async def _run_wait(args: list[str], target_spec: str | None, url_spec: str | None) -> None:
+    """Block until a CDP event fires. Exits 1 on timeout."""
+    from .errors import CDPError, NoPageError
+    from .page_ops import run_wait
+
+    instance_name, rest = _split_instance(args=args)
+
+    events: list[str] = []
+    contains: list[str] = []
+    timeout = 30.0
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--timeout" and i + 1 < len(rest):
+            try:
+                timeout = float(rest[i + 1])
+            except ValueError:
+                print(f"Error: invalid timeout: {rest[i + 1]}", file=sys.stderr)
+                sys.exit(1)
+            i += 2
+        elif rest[i] == "--contains" and i + 1 < len(rest):
+            contains.append(rest[i + 1])
+            i += 2
+        elif rest[i].startswith("--"):
+            print(f"Error: unknown wait option: {rest[i]}", file=sys.stderr)
+            sys.exit(1)
+        else:
+            # A leading '+' is accepted so attach and wait subscribe alike.
+            events.append(rest[i].lstrip("+"))
+            i += 1
+
+    if not events:
+        print("Error: no event named", file=sys.stderr)
+        print("Usage: chrome-agent wait [<instance>] <Domain.event ...> [--timeout SECS]", file=sys.stderr)
+        sys.exit(1)
+
+    port = _resolve_port_or_exit(instance_name=instance_name)
+
+    from .attach import AmbiguousTargetError, TargetNotFoundError
+    try:
+        event = await run_wait(
+            events=events,
+            port=port,
+            timeout=timeout,
+            contains=contains,
+            target_spec=target_spec,
+            url_spec=url_spec,
+        )
+    except CDPError as exc:
+        print(f"CDP error {exc.code}: {exc.message}", file=sys.stderr)
+        sys.exit(1)
+    except (AmbiguousTargetError, TargetNotFoundError, NoPageError, ConnectionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if event is None:
+        print(
+            f"Timed out after {timeout:g}s waiting for: {', '.join(events)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(json.dumps(event))
+
+
+async def _run_navigate(args: list[str], target_spec: str | None, url_spec: str | None) -> None:
+    """Navigate a page, wait for the load, and report the HTTP status."""
+    from .errors import CDPError, NoPageError
+    from .page_ops import NavigationError, run_navigate
+
+    instance_name, rest = _split_instance(args=args)
+
+    url = None
+    wait_for = "load"
+    timeout = 30.0
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--wait" and i + 1 < len(rest):
+            wait_for = rest[i + 1]
+            i += 2
+        elif rest[i] == "--timeout" and i + 1 < len(rest):
+            try:
+                timeout = float(rest[i + 1])
+            except ValueError:
+                print(f"Error: invalid timeout: {rest[i + 1]}", file=sys.stderr)
+                sys.exit(1)
+            i += 2
+        elif url is None and not rest[i].startswith("--"):
+            url = rest[i]
+            i += 1
+        else:
+            print(f"Error: unknown navigate option: {rest[i]}", file=sys.stderr)
+            sys.exit(1)
+
+    if url is None:
+        print("Error: no URL given", file=sys.stderr)
+        print("Usage: chrome-agent navigate [<instance>] <URL> [--wait load|domcontentloaded|none]", file=sys.stderr)
+        sys.exit(1)
+    if wait_for not in ("load", "domcontentloaded", "none"):
+        print(f"Error: unknown --wait value: {wait_for}", file=sys.stderr)
+        sys.exit(1)
+
+    port = _resolve_port_or_exit(instance_name=instance_name)
+
+    from .attach import AmbiguousTargetError, TargetNotFoundError
+    try:
+        result = await run_navigate(
+            url=url,
+            port=port,
+            wait_for=wait_for,
+            timeout=timeout,
+            target_spec=target_spec,
+            url_spec=url_spec,
+        )
+    except NavigationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except CDPError as exc:
+        print(f"CDP error {exc.code}: {exc.message}", file=sys.stderr)
+        sys.exit(1)
+    except (AmbiguousTargetError, TargetNotFoundError, NoPageError, ConnectionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(result))
+    if result["loaded"] is False:
+        print(f"Warning: load did not finish within {timeout:g}s", file=sys.stderr)
         sys.exit(1)
 
 
@@ -492,6 +749,14 @@ def main() -> None:
             _run_cleanup()
         elif command == "guide":
             _print_guide(args=rest)
+        elif command == "eval":
+            asyncio.run(_run_eval(args=rest, target_spec=target_spec, url_spec=url_spec))
+        elif command == "screenshot":
+            asyncio.run(_run_screenshot(args=rest, target_spec=target_spec, url_spec=url_spec))
+        elif command == "wait":
+            asyncio.run(_run_wait(args=rest, target_spec=target_spec, url_spec=url_spec))
+        elif command == "navigate":
+            asyncio.run(_run_navigate(args=rest, target_spec=target_spec, url_spec=url_spec))
         return
 
     # Disambiguate "instance name" vs "bare Domain.method":

--- a/src/chrome_agent/cli.py
+++ b/src/chrome_agent/cli.py
@@ -406,6 +406,27 @@ async def _run_cdp_one_shot(
         sys.exit(1)
 
 
+def _reject_extra_positional(verb: str, first: str | None, extra: str) -> None:
+    """Fail a verb given a second positional, naming the likely cause.
+
+    The usual cause is a mistyped or already-stopped instance name: it is not
+    in the registry, so _split_instance leaves it in place and it is consumed
+    as the verb's own argument. Reporting only "unknown option" would point at
+    the wrong token entirely.
+    """
+    if first is not None and not first.startswith("-"):
+        print(
+            f"Error: unexpected argument: {extra}\n"
+            f"       '{first}' was read as the argument to {verb}; "
+            f"if it is an instance name, it is not registered "
+            f"(check: chrome-agent status)",
+            file=sys.stderr,
+        )
+    else:
+        print(f"Error: unknown {verb} option: {extra}", file=sys.stderr)
+    sys.exit(1)
+
+
 def _resolve_port_or_exit(instance_name: str | None) -> int:
     """Resolve an instance to a port, or exit 1 with the reason."""
     from .page_ops import (
@@ -465,8 +486,9 @@ async def _run_eval(args: list[str], target_spec: str | None, url_spec: str | No
             expression = rest[i]
             i += 1
         else:
-            print(f"Error: unknown eval option: {rest[i]}", file=sys.stderr)
-            sys.exit(1)
+            _reject_extra_positional(
+                verb="eval", first=expression, extra=rest[i]
+            )
 
     if source_path is not None:
         if expression is not None:
@@ -677,8 +699,7 @@ async def _run_navigate(args: list[str], target_spec: str | None, url_spec: str 
             url = rest[i]
             i += 1
         else:
-            print(f"Error: unknown navigate option: {rest[i]}", file=sys.stderr)
-            sys.exit(1)
+            _reject_extra_positional(verb="navigate", first=url, extra=rest[i])
 
     if url is None:
         print("Error: no URL given", file=sys.stderr)

--- a/src/chrome_agent/launcher.py
+++ b/src/chrome_agent/launcher.py
@@ -35,16 +35,68 @@ class BrowserNotFoundError(Exception):
         )
 
 
-def find_chrome_binary() -> str | None:
-    """Search platform-specific paths for Chrome/Chromium.
+BINARY_ENV_VAR = "CHROME_AGENT_BINARY"
 
-    Returns the path to the first found executable, or None.
+
+def find_chrome_binary(binary: str | None = None) -> str | None:
+    """Locate a Chrome/Chromium executable.
+
+    Resolution order:
+
+      1. An explicit binary (``--binary``), or ``$CHROME_AGENT_BINARY``. When
+         either is set it is authoritative: a bad path is an error, not a
+         silent fallback to some other browser the caller did not ask for.
+      2. The platform's well-known absolute install paths.
+      3. A ``$PATH`` lookup of the usual executable names, which is what
+         reaches non-root installs, Chrome for Testing, ``/usr/local/bin``,
+         Homebrew, and Nix.
+
+    Returns the path to the first executable found, or None.
     """
-    candidates = _platform_candidates()
-    for path in candidates:
-        if os.path.isfile(path) and os.access(path, os.X_OK):
+    override = binary or os.environ.get(BINARY_ENV_VAR)
+    if override:
+        return override if _is_executable(path=override) else None
+
+    for path in _candidate_paths():
+        if _is_executable(path=path):
             return path
     return None
+
+
+def _is_executable(path: str) -> bool:
+    """Whether path is a file this process may execute."""
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def _candidate_paths(binary: str | None = None) -> list[str]:
+    """Every path find_chrome_binary would consider, in resolution order.
+
+    Doubles as the "searched" listing on BrowserNotFoundError, so the error
+    always names exactly what was tried -- including a bad override.
+    """
+    override = binary or os.environ.get(BINARY_ENV_VAR)
+    if override:
+        return [override]
+
+    candidates = list(_platform_candidates())
+    for name in _platform_binary_names():
+        resolved = shutil.which(name)
+        if resolved and resolved not in candidates:
+            candidates.append(resolved)
+    return candidates
+
+
+def _platform_binary_names() -> list[str]:
+    """Executable names to look for on $PATH."""
+    if sys.platform == "win32":
+        return ["chrome.exe", "chromium.exe"]
+    return [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium-browser",
+        "chromium",
+        "chrome",
+    ]
 
 
 def _platform_candidates() -> list[str]:
@@ -79,6 +131,7 @@ async def launch_browser(
     registry_path: str | None = None,
     extra_args: list[str] | None = None,
     window_border: bool = True,
+    binary: str | None = None,
 ) -> InstanceInfo:
     """Launch Chrome with CDP enabled and register as a named instance.
 
@@ -92,15 +145,17 @@ async def launch_browser(
 
     Returns InstanceInfo with name, port, pid, browser_version, user_data_dir.
 
+    binary overrides browser discovery (see find_chrome_binary).
+
     Raises BrowserNotFoundError if Chrome is not installed.
     Raises RuntimeError if no ports are available.
     Raises TimeoutError if the browser doesn't start within 30 seconds.
     """
 
     # Phase 1: Find Chrome binary
-    binary = find_chrome_binary()
-    if binary is None:
-        raise BrowserNotFoundError(searched_paths=_platform_candidates())
+    resolved_binary = find_chrome_binary(binary=binary)
+    if resolved_binary is None:
+        raise BrowserNotFoundError(searched_paths=_candidate_paths(binary=binary))
 
     # Prune truly-dead instances first (fallback for browsers whose supervisor
     # was killed, and for headless instances which have no supervisor), and
@@ -135,7 +190,7 @@ async def launch_browser(
         json.dump(prefs, f)
 
     args = [
-        binary,
+        resolved_binary,
         f"--remote-debugging-port={port}",
         f"--user-data-dir={session_dir}",
         "--no-first-run",

--- a/src/chrome_agent/page_ops.py
+++ b/src/chrome_agent/page_ops.py
@@ -1,0 +1,453 @@
+"""Page operations built on the one-shot CDP channel.
+
+These are convenience verbs -- `eval`, `screenshot`, `wait` -- over the same
+primitives the raw `chrome-agent <instance> Domain.method` form exposes. They
+exist because three things an agent does constantly are painful to express as
+a single raw command:
+
+  * `Runtime.evaluate` requires JavaScript nested inside a JSON string nested
+    inside a shell argument, so any non-trivial expression dies of quoting.
+  * `Page.captureScreenshot` returns base64 that has to be decoded by hand.
+  * Waiting for an event otherwise means a fixed `sleep`, which is exactly
+    what this tool's guidance tells agents not to do.
+
+Nothing here gates the protocol: every verb is a thin wrapper, and the raw
+form still reaches any method, including ones these wrappers never mention.
+"""
+
+import asyncio
+import base64
+import json
+import os
+from contextlib import asynccontextmanager
+
+from .cdp_client import CDPClient, get_ws_url
+from .errors import CDPError, NoPageError
+from . import registry
+from .registry import InstanceNotFoundError
+
+
+class NoLiveInstanceError(Exception):
+    """No live instance to auto-select."""
+
+
+class AmbiguousInstanceError(Exception):
+    """More than one live instance and no name given."""
+
+    def __init__(self, names: list[str]):
+        self.names = names
+        super().__init__(
+            "multiple instances running. Specify one: " + ", ".join(names)
+        )
+
+
+class EvaluationError(Exception):
+    """The page threw while evaluating the expression."""
+
+
+class NavigationError(Exception):
+    """Chrome refused the navigation (bad scheme, DNS failure, blocked)."""
+
+
+def resolve_port(
+    instance_name: str | None = None,
+    registry_path: str | None = None,
+) -> int:
+    """Resolve an instance name (or the single live instance) to a CDP port.
+
+    Raises InstanceNotFoundError, NoLiveInstanceError, or
+    AmbiguousInstanceError.
+    """
+    # Resolved through the module, not a from-import, so a caller (or test)
+    # that swaps the registry's functions is honored here too.
+    if instance_name is not None:
+        return registry.lookup(
+            instance_name=instance_name, registry_path=registry_path
+        ).port
+
+    live = [
+        i for i in registry.enumerate_instances(registry_path=registry_path) if i.alive
+    ]
+    if not live:
+        raise NoLiveInstanceError(
+            "no instances registered. Launch one with: chrome-agent launch"
+        )
+    if len(live) > 1:
+        raise AmbiguousInstanceError(names=[i.name for i in live])
+    return live[0].port
+
+
+def target_selector(
+    target_spec: str | None,
+    url_spec: str | None,
+) -> tuple[str | None, str | None]:
+    """Map the --target/--url flags onto resolve_target's (spec, target_by)."""
+    if target_spec is not None:
+        return target_spec, ("index" if target_spec.isdigit() else "id")
+    if url_spec is not None:
+        return url_spec, "url"
+    return None, None
+
+
+@asynccontextmanager
+async def attached_page_session(
+    port: int,
+    target_spec: str | None = None,
+    url_spec: str | None = None,
+):
+    """Yield (client, session_id) for an isolated session on one page target.
+
+    Connects to the browser-level endpoint, resolves the page target, and
+    attaches a flattened session -- the same sequence one-shot commands use,
+    so every caller gets identical target-selection and isolation semantics.
+    The session is always detached on exit.
+    """
+    from .attach import resolve_target
+
+    browser_ws_url = get_ws_url(port=port, target_type="browser")
+    async with CDPClient(ws_url=browser_ws_url) as cdp:
+        targets_result = await cdp.send(method="Target.getTargets")
+        page_targets = sorted(
+            (t for t in targets_result.get("targetInfos", [])
+             if t.get("type") == "page"),
+            key=lambda t: t.get("targetId", ""),
+        )
+        if not page_targets:
+            raise NoPageError("No page targets in browser")
+
+        spec, target_by = target_selector(target_spec=target_spec, url_spec=url_spec)
+        target_id = resolve_target(
+            page_targets=page_targets,
+            target_spec=spec,
+            target_by=target_by,
+        )
+
+        result = await cdp.send(
+            method="Target.attachToTarget",
+            params={"targetId": target_id, "flatten": True},
+        )
+        session_id = result["sessionId"]
+
+        try:
+            yield cdp, session_id
+        finally:
+            try:
+                await cdp.send(
+                    method="Target.detachFromTarget",
+                    params={"sessionId": session_id},
+                )
+            except Exception:
+                pass  # Session may already be gone with its target
+
+
+async def run_eval(
+    expression: str,
+    port: int,
+    target_spec: str | None = None,
+    url_spec: str | None = None,
+    raw_json: bool = False,
+) -> str:
+    """Evaluate JavaScript in the page and return it rendered for stdout.
+
+    Promises are awaited. By default the returned value is unwrapped -- a
+    string prints as itself, anything else as indented JSON -- because the
+    caller almost never wants the CDP envelope. raw_json returns the full
+    Runtime.evaluate response instead.
+
+    Raises EvaluationError if the page threw.
+    """
+    async with attached_page_session(
+        port=port, target_spec=target_spec, url_spec=url_spec
+    ) as (cdp, session_id):
+        response = await cdp.send(
+            method="Runtime.evaluate",
+            params={
+                "expression": expression,
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+            session_id=session_id,
+        )
+
+    details = response.get("exceptionDetails")
+    if details:
+        raise EvaluationError(_format_exception(details=details))
+
+    if raw_json:
+        return json.dumps(response, indent=2)
+
+    remote = response.get("result", {})
+    if "value" not in remote:
+        # undefined, or an object CDP declined to serialize by value.
+        return remote.get("description") or remote.get("type", "undefined")
+
+    value = remote["value"]
+    return value if isinstance(value, str) else json.dumps(value, indent=2, ensure_ascii=False)
+
+
+def _format_exception(details: dict) -> str:
+    """Render Runtime.exceptionDetails as a single readable line."""
+    exception = details.get("exception") or {}
+    text = (
+        exception.get("description")
+        or exception.get("value")
+        or details.get("text")
+        or "evaluation failed"
+    )
+    line = details.get("lineNumber")
+    if line is not None:
+        return f"{text} (line {line + 1})"
+    return str(text)
+
+
+async def run_screenshot(
+    port: int,
+    output_path: str,
+    image_format: str = "png",
+    quality: int | None = None,
+    full_page: bool = False,
+    selector: str | None = None,
+    target_spec: str | None = None,
+    url_spec: str | None = None,
+) -> tuple[str, int]:
+    """Capture the page to a file. Returns (absolute path, bytes written).
+
+    full_page captures the whole scrollable content rather than the viewport.
+    selector captures just the first element matching a CSS selector, scrolled
+    into view first. The two are mutually exclusive at the CLI layer.
+
+    Raises EvaluationError if selector matches nothing.
+    """
+    params: dict = {"format": image_format}
+    if quality is not None and image_format == "jpeg":
+        params["quality"] = quality
+
+    async with attached_page_session(
+        port=port, target_spec=target_spec, url_spec=url_spec
+    ) as (cdp, session_id):
+        if selector is not None:
+            clip = await _selector_clip(
+                cdp=cdp, session_id=session_id, selector=selector
+            )
+            params["clip"] = clip
+            params["captureBeyondViewport"] = True
+        elif full_page:
+            metrics = await cdp.send(
+                method="Page.getLayoutMetrics", session_id=session_id
+            )
+            content = metrics.get("cssContentSize") or metrics.get("contentSize", {})
+            params["clip"] = {
+                "x": 0,
+                "y": 0,
+                "width": content.get("width", 0),
+                "height": content.get("height", 0),
+                "scale": 1,
+            }
+            params["captureBeyondViewport"] = True
+
+        response = await cdp.send(
+            method="Page.captureScreenshot",
+            params=params,
+            session_id=session_id,
+        )
+
+    data = base64.b64decode(response["data"])
+    path = os.path.abspath(output_path)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "wb") as handle:
+        handle.write(data)
+    return path, len(data)
+
+
+async def _selector_clip(cdp: CDPClient, session_id: str, selector: str) -> dict:
+    """Return a capture clip for the first element matching selector."""
+    expression = (
+        "(() => {"
+        f"  const el = document.querySelector({json.dumps(selector)});"
+        "  if (!el) return null;"
+        "  el.scrollIntoView({block: 'center', inline: 'center'});"
+        "  const r = el.getBoundingClientRect();"
+        "  return {x: r.x + window.scrollX, y: r.y + window.scrollY,"
+        "          width: r.width, height: r.height};"
+        "})()"
+    )
+    response = await cdp.send(
+        method="Runtime.evaluate",
+        params={"expression": expression, "returnByValue": True},
+        session_id=session_id,
+    )
+    if response.get("exceptionDetails"):
+        raise EvaluationError(_format_exception(details=response["exceptionDetails"]))
+
+    box = response.get("result", {}).get("value")
+    if not box:
+        raise EvaluationError(f"no element matches selector: {selector}")
+    if not box["width"] or not box["height"]:
+        raise EvaluationError(f"element has zero size: {selector}")
+
+    return {
+        "x": box["x"],
+        "y": box["y"],
+        "width": box["width"],
+        "height": box["height"],
+        "scale": 1,
+    }
+
+
+async def run_wait(
+    events: list[str],
+    port: int,
+    timeout: float = 30.0,
+    contains: list[str] | None = None,
+    target_spec: str | None = None,
+    url_spec: str | None = None,
+) -> dict | None:
+    """Block until one of the named CDP events fires. Returns it, or None.
+
+    Only events that fire *after* the subscription is live can match: this
+    opens its own session, so anything that already happened is gone. To catch
+    an event that may fire before the wait begins, background `attach` to a
+    file first and match against that (scripts/cdp-wait.py).
+
+    contains narrows a match to events whose JSON holds every given substring.
+    """
+    matched: asyncio.Queue = asyncio.Queue(maxsize=1)
+    needles = contains or []
+
+    def _handler(event_name: str):
+        def callback(params):
+            if matched.full():
+                return
+            event = {"method": event_name, "params": params}
+            if needles:
+                blob = json.dumps(event)
+                if not all(needle in blob for needle in needles):
+                    return
+            try:
+                matched.put_nowait(event)
+            except asyncio.QueueFull:
+                pass
+        return callback
+
+    async with attached_page_session(
+        port=port, target_spec=target_spec, url_spec=url_spec
+    ) as (cdp, session_id):
+        enabled: set[str] = set()
+        for event_name in events:
+            domain = event_name.split(".")[0]
+            if domain not in enabled:
+                try:
+                    await cdp.send(method=f"{domain}.enable", session_id=session_id)
+                except CDPError:
+                    pass  # Not every domain has an enable
+                enabled.add(domain)
+            cdp.on(
+                event=event_name,
+                callback=_handler(event_name=event_name),
+                session_id=session_id,
+            )
+
+        try:
+            return await asyncio.wait_for(matched.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+
+async def run_navigate(
+    url: str,
+    port: int,
+    wait_for: str = "load",
+    timeout: float = 30.0,
+    target_spec: str | None = None,
+    url_spec: str | None = None,
+) -> dict:
+    """Navigate a page and report what actually happened.
+
+    Raw `Page.navigate` returns as soon as the navigation is *committed*, and
+    its result carries no HTTP status -- so a 404 and a 200 are indistinguishable
+    without a second round trip, and any following command races the load. This
+    waits for the document to finish (wait_for: "load", "domcontentloaded", or
+    "none") and reports the main document's status code.
+
+    Returns {"url", "status", "frameId", "loaderId", "loaded", "elapsedMs"};
+    "loaded" is null when wait_for is "none".
+    Raises NavigationError if Chrome refused the navigation outright.
+    """
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+
+    async with attached_page_session(
+        port=port, target_spec=target_spec, url_spec=url_spec
+    ) as (cdp, session_id):
+        await cdp.send(method="Page.enable", session_id=session_id)
+        await cdp.send(method="Network.enable", session_id=session_id)
+
+        statuses: dict[str, dict] = {}
+        finished = asyncio.Event()
+
+        def on_response(params):
+            if params.get("type") == "Document":
+                loader_id = params.get("loaderId")
+                if loader_id:
+                    statuses[loader_id] = params.get("response", {})
+
+        def on_finished(params):
+            finished.set()
+
+        cdp.on(event="Network.responseReceived", callback=on_response, session_id=session_id)
+        if wait_for == "domcontentloaded":
+            cdp.on(
+                event="Page.domContentEventFired",
+                callback=on_finished,
+                session_id=session_id,
+            )
+        elif wait_for == "load":
+            cdp.on(
+                event="Page.loadEventFired", callback=on_finished, session_id=session_id
+            )
+
+        result = await cdp.send(
+            method="Page.navigate", params={"url": url}, session_id=session_id
+        )
+        if result.get("errorText"):
+            raise NavigationError(f"{result['errorText']} ({url})")
+
+        # None, not True: with wait_for="none" nothing was waited on, and
+        # claiming the document loaded would be a fact this never checked.
+        loaded = None
+        if wait_for != "none":
+            loaded = True
+            try:
+                await asyncio.wait_for(finished.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                loaded = False
+
+        loader_id = result.get("loaderId")
+        response = statuses.get(loader_id, {})
+
+        return {
+            "url": response.get("url", url),
+            "status": response.get("status"),
+            "frameId": result.get("frameId"),
+            "loaderId": loader_id,
+            "loaded": loaded,
+            "elapsedMs": round((loop.time() - started) * 1000),
+        }
+
+
+__all__ = [
+    "AmbiguousInstanceError",
+    "EvaluationError",
+    "InstanceNotFoundError",
+    "NavigationError",
+    "NoLiveInstanceError",
+    "attached_page_session",
+    "resolve_port",
+    "run_eval",
+    "run_navigate",
+    "run_screenshot",
+    "run_wait",
+    "target_selector",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,7 +324,7 @@ def test_launch_chrome_not_found_clean_error(monkeypatch, capsys):
 
     from chrome_agent import cli
 
-    monkeypatch.setattr("chrome_agent.launcher.find_chrome_binary", lambda: None)
+    monkeypatch.setattr("chrome_agent.launcher.find_chrome_binary", lambda binary=None: None)
     with pytest.raises(SystemExit) as exc_info:
         asyncio.run(cli._run_launch(args=[]))
     assert exc_info.value.code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -427,3 +427,21 @@ def test_unregistered_dotted_first_arg_routes_as_method(monkeypatch):
     # Auto-select path: instance_name is None, method is the dotted first arg
     assert captured["instance_name"] is None
     assert captured["method"] == "Runtime.evaluate"
+
+
+def test_eval_unregistered_instance_names_the_cause(browser_session):
+    """A stale instance name must not be reported as a bad expression.
+
+    An unregistered leading token stays in the verb's arguments, so the
+    expression lands in the option slot; the error has to point at the real
+    cause instead of the last token it happened to choke on.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "chrome_agent", "eval", "gone-01", "document.title"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 1
+    assert "not registered" in result.stderr
+    assert "gone-01" in result.stderr

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -18,8 +18,10 @@ import pytest
 
 from chrome_agent.connection import check_cdp_port
 from chrome_agent.launcher import (
+    BINARY_ENV_VAR,
     BrowserNotFoundError,
     _SESSION_ROOT,
+    _candidate_paths,
     cleanup_sessions,
     find_chrome_binary,
     launch_browser,
@@ -150,7 +152,7 @@ def test_browser_not_found(monkeypatch):
     """Raises BrowserNotFoundError when no Chrome binary exists."""
     monkeypatch.setattr(
         "chrome_agent.launcher.find_chrome_binary",
-        lambda: None,
+        lambda binary=None: None,
     )
 
     async def do_launch():
@@ -251,3 +253,79 @@ async def test_cleanup_preserves_active_dirs(tmp_path):
     finally:
         os.kill(result.pid, signal.SIGTERM)
         await asyncio.sleep(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Binary discovery overrides (explicit path, env var, $PATH)
+# ---------------------------------------------------------------------------
+
+
+def _fake_binary(tmp_path, name="my-chrome"):
+    """Create an executable stub standing in for a Chrome install."""
+    path = tmp_path / name
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+    return str(path)
+
+
+def test_explicit_binary_wins_over_system_paths(tmp_path, monkeypatch):
+    """An explicit binary is used even when a system Chrome exists."""
+    binary = _fake_binary(tmp_path)
+    monkeypatch.setattr(
+        "chrome_agent.launcher._platform_candidates", lambda: ["/usr/bin/google-chrome"]
+    )
+    assert find_chrome_binary(binary=binary) == binary
+
+
+def test_env_var_overrides_system_paths(tmp_path, monkeypatch):
+    """$CHROME_AGENT_BINARY reaches installs outside the known paths."""
+    binary = _fake_binary(tmp_path)
+    monkeypatch.setenv(BINARY_ENV_VAR, binary)
+    monkeypatch.setattr("chrome_agent.launcher._platform_candidates", lambda: [])
+    assert find_chrome_binary() == binary
+
+
+def test_bad_override_does_not_fall_back(tmp_path, monkeypatch):
+    """A bad override is an error, not a silent switch to another browser.
+
+    Falling back would launch a browser the caller did not ask for, which is
+    worse than failing: fingerprint and profile expectations silently differ.
+    """
+    monkeypatch.setattr(
+        "chrome_agent.launcher._platform_candidates", lambda: ["/usr/bin/google-chrome"]
+    )
+    missing = str(tmp_path / "nope")
+    assert find_chrome_binary(binary=missing) is None
+    assert _candidate_paths(binary=missing) == [missing]
+
+
+def test_path_lookup_finds_binary_outside_known_paths(tmp_path, monkeypatch):
+    """A Chrome only on $PATH is found once the absolute paths miss."""
+    binary = _fake_binary(tmp_path, name="google-chrome")
+    monkeypatch.setattr("chrome_agent.launcher._platform_candidates", lambda: [])
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.delenv(BINARY_ENV_VAR, raising=False)
+    assert find_chrome_binary() == binary
+
+
+def test_system_paths_take_precedence_over_path_lookup(tmp_path, monkeypatch):
+    """The $PATH fallback never displaces an existing system install."""
+    system = _fake_binary(tmp_path, name="system-chrome")
+    shadow = _fake_binary(tmp_path, name="google-chrome")
+    monkeypatch.setattr("chrome_agent.launcher._platform_candidates", lambda: [system])
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.delenv(BINARY_ENV_VAR, raising=False)
+    assert find_chrome_binary() == system
+    assert _candidate_paths() == [system, shadow]
+
+
+def test_not_found_error_lists_path_candidates(monkeypatch):
+    """The error names every location tried, including $PATH resolutions."""
+    monkeypatch.setattr("chrome_agent.launcher._platform_candidates", lambda: ["/nope/chrome"])
+    monkeypatch.setattr("chrome_agent.launcher.shutil.which", lambda name: "/usr/local/bin/" + name)
+    monkeypatch.delenv(BINARY_ENV_VAR, raising=False)
+    candidates = _candidate_paths()
+    assert "/nope/chrome" in candidates
+    assert any(c.startswith("/usr/local/bin/") for c in candidates)
+    message = str(BrowserNotFoundError(searched_paths=candidates))
+    assert "/nope/chrome" in message

--- a/tests/test_page_ops.py
+++ b/tests/test_page_ops.py
@@ -1,0 +1,329 @@
+"""Tests for the page convenience verbs: eval, screenshot, wait.
+
+Exercises the real functions against the session's headless browser, so a
+regression in target attachment, value unwrapping, clipping, or event
+subscription fails here rather than in an agent's session.
+"""
+
+import asyncio
+import json
+import struct
+
+import pytest
+
+from chrome_agent.page_ops import (
+    AmbiguousInstanceError,
+    EvaluationError,
+    NavigationError,
+    NoLiveInstanceError,
+    attached_page_session,
+    resolve_port,
+    run_eval,
+    run_navigate,
+    run_screenshot,
+    run_wait,
+    target_selector,
+)
+
+CDP_PORT = 9333  # matches conftest's browser_session fixture
+
+
+def _png_size(path) -> tuple[int, int]:
+    """Width and height from a PNG's IHDR chunk."""
+    with open(path, "rb") as handle:
+        header = handle.read(24)
+    assert header[:8] == b"\x89PNG\r\n\x1a\n", "not a PNG"
+    return struct.unpack(">II", header[16:24])
+
+
+async def _goto(url: str) -> None:
+    """Navigate the browser's page target and wait for load."""
+    async with attached_page_session(port=CDP_PORT) as (cdp, session_id):
+        await cdp.send(method="Page.enable", session_id=session_id)
+        await cdp.send(
+            method="Page.navigate", params={"url": url}, session_id=session_id
+        )
+    # Give the load a moment; the fixture is a local file.
+    await asyncio.sleep(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Instance resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_port_by_name(browser_session, tmp_path, monkeypatch):
+    """A named instance resolves to its recorded port."""
+    from chrome_agent import registry
+
+    registry_path = str(tmp_path / "registry.json")
+    registry.register(
+        working_dir="/tmp/proj",
+        pid=1,
+        browser_version="Chrome/1",
+        user_data_dir="/tmp/none",
+        port_override=4321,
+        registry_path=registry_path,
+    )
+    assert resolve_port(instance_name="proj-01", registry_path=registry_path) == 4321
+
+
+def test_resolve_port_no_instances(tmp_path):
+    """No registered instance is an error, not a silent default."""
+    with pytest.raises(NoLiveInstanceError):
+        resolve_port(registry_path=str(tmp_path / "empty.json"))
+
+
+def test_resolve_port_ambiguous(tmp_path, monkeypatch):
+    """Two live instances with no name given must not be guessed between."""
+    from chrome_agent import registry
+
+    fake = [
+        registry.InstanceInfo(name="a-01", port=1, pid=1, browser_version="", alive=True),
+        registry.InstanceInfo(name="b-01", port=2, pid=2, browser_version="", alive=True),
+    ]
+    monkeypatch.setattr(registry, "enumerate_instances", lambda registry_path=None: fake)
+    with pytest.raises(AmbiguousInstanceError) as exc_info:
+        resolve_port()
+    assert "a-01" in str(exc_info.value) and "b-01" in str(exc_info.value)
+
+
+def test_target_selector_forms():
+    """--target digits mean index, non-digits mean id, --url means url."""
+    assert target_selector(target_spec="2", url_spec=None) == ("2", "index")
+    assert target_selector(target_spec="A1B2", url_spec=None) == ("A1B2", "id")
+    assert target_selector(target_spec=None, url_spec="example") == ("example", "url")
+    assert target_selector(target_spec=None, url_spec=None) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# eval
+# ---------------------------------------------------------------------------
+
+
+def test_eval_returns_string_unwrapped(browser_session, event_loop, fixture_url):
+    """A string result prints as itself, not as a CDP envelope."""
+    event_loop.run_until_complete(_goto(fixture_url))
+    out = event_loop.run_until_complete(
+        run_eval(expression="document.title", port=CDP_PORT)
+    )
+    assert out == "chrome-agent test fixture"
+
+
+def test_eval_returns_object_as_json(browser_session, event_loop):
+    """An object result is rendered as JSON the caller can parse."""
+    out = event_loop.run_until_complete(
+        run_eval(expression="({a: 1, b: [2, 3]})", port=CDP_PORT)
+    )
+    assert json.loads(out) == {"a": 1, "b": [2, 3]}
+
+
+def test_eval_awaits_promises(browser_session, event_loop):
+    """A promise is awaited rather than returned as an unresolved object."""
+    out = event_loop.run_until_complete(
+        run_eval(expression="Promise.resolve(7)", port=CDP_PORT)
+    )
+    assert out == "7"
+
+
+def test_eval_raises_on_page_exception(browser_session, event_loop):
+    """A thrown error surfaces as EvaluationError, not a silent success."""
+    with pytest.raises(EvaluationError) as exc_info:
+        event_loop.run_until_complete(
+            run_eval(expression="throw new Error('boom')", port=CDP_PORT)
+        )
+    assert "boom" in str(exc_info.value)
+
+
+def test_eval_raw_json_keeps_envelope(browser_session, event_loop):
+    """--json returns the full Runtime.evaluate response."""
+    out = event_loop.run_until_complete(
+        run_eval(expression="1 + 1", port=CDP_PORT, raw_json=True)
+    )
+    assert json.loads(out)["result"]["value"] == 2
+
+
+def test_eval_undefined_is_described(browser_session, event_loop):
+    """An undefined result is reported, not printed as an empty line."""
+    out = event_loop.run_until_complete(
+        run_eval(expression="void 0", port=CDP_PORT)
+    )
+    assert out == "undefined"
+
+
+# ---------------------------------------------------------------------------
+# screenshot
+# ---------------------------------------------------------------------------
+
+
+def test_screenshot_writes_png(browser_session, event_loop, fixture_url, tmp_path):
+    """Viewport capture writes a decodable PNG and reports its size."""
+    event_loop.run_until_complete(_goto(fixture_url))
+    out = tmp_path / "shot.png"
+    path, size = event_loop.run_until_complete(
+        run_screenshot(port=CDP_PORT, output_path=str(out))
+    )
+    assert path == str(out.resolve())
+    assert size == out.stat().st_size > 0
+    width, height = _png_size(out)
+    assert width > 0 and height > 0
+
+
+def test_screenshot_full_page_is_taller_than_viewport(
+    browser_session, event_loop, tmp_path
+):
+    """--full-page captures scrollable content beyond the viewport."""
+    event_loop.run_until_complete(
+        _goto("data:text/html,<body style='margin:0'>"
+              "<div style='height:4000px;background:linear-gradient(red,blue)'></div>")
+    )
+    viewport = tmp_path / "viewport.png"
+    full = tmp_path / "full.png"
+    event_loop.run_until_complete(
+        run_screenshot(port=CDP_PORT, output_path=str(viewport))
+    )
+    event_loop.run_until_complete(
+        run_screenshot(port=CDP_PORT, output_path=str(full), full_page=True)
+    )
+    assert _png_size(full)[1] > _png_size(viewport)[1]
+
+
+def test_screenshot_selector_clips_to_element(browser_session, event_loop, tmp_path):
+    """--selector captures only the matched element."""
+    event_loop.run_until_complete(
+        _goto("data:text/html,<body style='margin:0'>"
+              "<div id='box' style='width:120px;height:60px;background:teal'></div>")
+    )
+    out = tmp_path / "el.png"
+    event_loop.run_until_complete(
+        run_screenshot(port=CDP_PORT, output_path=str(out), selector="#box")
+    )
+    width, height = _png_size(out)
+    assert (width, height) == (120, 60)
+
+
+def test_screenshot_missing_selector_errors(browser_session, event_loop, tmp_path):
+    """A selector that matches nothing fails loudly and writes no file."""
+    out = tmp_path / "missing.png"
+    with pytest.raises(EvaluationError):
+        event_loop.run_until_complete(
+            run_screenshot(port=CDP_PORT, output_path=str(out), selector="#nope")
+        )
+    assert not out.exists()
+
+
+def test_screenshot_creates_parent_directory(
+    browser_session, event_loop, fixture_url, tmp_path
+):
+    """A path in a not-yet-existing directory is created, not rejected."""
+    out = tmp_path / "nested" / "deep" / "shot.png"
+    event_loop.run_until_complete(
+        run_screenshot(port=CDP_PORT, output_path=str(out))
+    )
+    assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# wait
+# ---------------------------------------------------------------------------
+
+
+def test_wait_returns_matching_event(browser_session, event_loop, fixture_url):
+    """wait returns the event that fires after subscription."""
+
+    async def scenario():
+        waiter = asyncio.ensure_future(
+            run_wait(events=["Page.loadEventFired"], port=CDP_PORT, timeout=15.0)
+        )
+        await asyncio.sleep(0.5)  # let the subscription go live
+        await _goto(fixture_url)
+        return await waiter
+
+    event = event_loop.run_until_complete(scenario())
+    assert event is not None
+    assert event["method"] == "Page.loadEventFired"
+
+
+def test_wait_times_out_to_none(browser_session, event_loop):
+    """A quiet page yields None so the CLI can exit non-zero."""
+    event = event_loop.run_until_complete(
+        run_wait(events=["Page.loadEventFired"], port=CDP_PORT, timeout=1.0)
+    )
+    assert event is None
+
+
+def test_wait_contains_filters_non_matching_events(
+    browser_session, event_loop, fixture_url
+):
+    """--contains rejects events that fire but do not hold the substring."""
+
+    async def scenario():
+        waiter = asyncio.ensure_future(
+            run_wait(
+                events=["Page.loadEventFired"],
+                port=CDP_PORT,
+                timeout=3.0,
+                contains=["definitely-not-in-this-event"],
+            )
+        )
+        await asyncio.sleep(0.5)
+        await _goto(fixture_url)
+        return await waiter
+
+    assert event_loop.run_until_complete(scenario()) is None
+
+
+# ---------------------------------------------------------------------------
+# navigate
+# ---------------------------------------------------------------------------
+
+
+def test_navigate_reports_load_and_identity(browser_session, event_loop, fixture_url):
+    """navigate waits for the load and returns the frame/loader identity."""
+    result = event_loop.run_until_complete(
+        run_navigate(url=fixture_url, port=CDP_PORT, timeout=15.0)
+    )
+    assert result["loaded"] is True
+    assert result["frameId"] and result["loaderId"]
+    assert result["elapsedMs"] >= 0
+
+
+def test_navigate_surfaces_http_status(browser_session, event_loop):
+    """The main document's status code is reported, so 404 != 200.
+
+    A bare Page.navigate returns the same shape either way, which is how a
+    404 page gets mistaken for content.
+    """
+    ok = event_loop.run_until_complete(
+        run_navigate(
+            url="data:text/html,<title>ok</title>", port=CDP_PORT, timeout=15.0
+        )
+    )
+    # data: URLs have no HTTP status; the field is present and null, not absent.
+    assert "status" in ok
+
+    result = event_loop.run_until_complete(
+        run_navigate(url="https://example.com/", port=CDP_PORT, timeout=20.0)
+    )
+    assert result["status"] == 200
+
+
+def test_navigate_wait_none_reports_null_loaded(browser_session, event_loop, fixture_url):
+    """--wait none must not claim a load it never observed."""
+    result = event_loop.run_until_complete(
+        run_navigate(url=fixture_url, port=CDP_PORT, wait_for="none")
+    )
+    assert result["loaded"] is None
+
+
+def test_navigate_raises_on_refused_navigation(browser_session, event_loop):
+    """A DNS failure is an error, not a silently "successful" navigation."""
+    with pytest.raises(NavigationError) as exc_info:
+        event_loop.run_until_complete(
+            run_navigate(
+                url="https://this-host-does-not-exist-zzz.invalid/",
+                port=CDP_PORT,
+                timeout=15.0,
+            )
+        )
+    assert "ERR_NAME_NOT_RESOLVED" in str(exc_info.value)


### PR DESCRIPTION
Four changes, all from friction hit while driving `chrome-agent` through a real session (setting the tool up on a fresh Ubuntu box, then using it to research an article and drive a browser-based HDL playground).

Every console block below is a verbatim transcript, captured from this branch against Chrome 151 on Linux.

## 1. Chrome discovery beyond the five hardcoded paths

`find_chrome_binary()` checked five absolute paths and nothing else — no `$PATH`, no env var, no flag. On a machine where Chrome lives anywhere else (Chrome for Testing, a user-local install, `/usr/local/bin`, Homebrew, Nix), `launch` fails with "not found" on a system that has Chrome.

Discovery now falls back to a `$PATH` lookup after the absolute paths, and `--binary PATH` / `$CHROME_AGENT_BINARY` name a browser explicitly.

An override is **authoritative** — a bad path errors and names itself rather than silently launching a different browser than the caller asked for. Falling back there would be worse than failing: fingerprint and profile expectations silently differ from what was requested.

```console
$ chrome-agent launch --headless --binary /tmp/fakechrome/my-chrome
{"name": "chrome-agent-01", "port": 9223, "pid": 36685, "browser_version": "Chrome/151.0.7922.169"}

$ chrome-agent launch --headless --binary /tmp/nope
Error: Chrome/Chromium not found. Searched:
  /tmp/nope
$ echo $?
1
```

`$CHROME_AGENT_BINARY` takes the same path when no flag is given. Existing behaviour is unchanged when neither override is set: the platform's absolute paths still win, so a `$PATH` shim can never displace a system install.

## 2. `wait` — an event barrier instead of `sleep`

The README tells agents on non-Monitor harnesses not to fall back to fixed sleeps, then ships the answer as `scripts/cdp-wait.py`, which isn't in the package. Without a CLI verb, the practical result is `sleep 5` between every step (which is what I ended up writing, repeatedly, before this).

```console
$ chrome-agent wait proj-01 Page.loadEventFired --timeout 25   # navigation ran in another shell
{"method": "Page.loadEventFired", "params": {"timestamp": 5002.763586}}
$ echo $?
0

$ chrome-agent wait proj-01 Page.loadEventFired --timeout 3    # quiet page
Timed out after 3s waiting for: Page.loadEventFired
$ echo $?
1
```

`--contains SUBSTRING` narrows a match to events whose JSON holds every given substring, and the `+Event` form is accepted so `attach` and `wait` subscribe alike.

Scope is stated in the docs rather than fudged: `wait` opens its own session, so it can only match events that fire *after* it subscribes — `scripts/cdp-wait.py` over a backgrounded `attach` stream remains the answer for events that may fire first.

## 3. `navigate` — a load barrier and the HTTP status

`Page.navigate` returns `{frameId, loaderId, isDownload}` at commit time. It carries no status, so a 404 or a bot-block page is indistinguishable from real content until you inspect the DOM, and any following command races the load.

This cost me six wrong guesses in one session: probing category slugs to find an article, every miss returned a plausible-looking result and a page whose `document.title` was just the site name.

```console
$ chrome-agent navigate proj-01 https://example.com
{"url": "https://example.com/", "status": 200, "frameId": "D795C6AD...", "loaderId": "0C6789BA...", "loaded": true, "elapsedMs": 95}

$ chrome-agent navigate proj-01 https://example.com/definitely-not-a-real-slug/
{"url": "https://example.com/definitely-not-a-real-slug/", "status": 404, "frameId": "D795C6AD...", "loaderId": "B5A82F38...", "loaded": true, "elapsedMs": 45}

$ chrome-agent navigate proj-01 https://this-host-does-not-exist-zzz.invalid/
Error: net::ERR_NAME_NOT_RESOLVED (https://this-host-does-not-exist-zzz.invalid/)
$ echo $?
1
```

Same shape from `Page.navigate` for the first two; different `status`, which is the whole point. (Frame and loader ids truncated here for width; the real output prints them in full.)

`--wait load|domcontentloaded|none`. `--wait none` reports `"loaded": null` rather than claiming a load it never observed; a load that doesn't finish within `--timeout` prints the result and exits 1.

## 4. `eval` and `screenshot` — the plumbing tax

`Runtime.evaluate` means JavaScript inside a JSON string inside a shell argument. Anything non-trivial dies of quoting — during the session that produced this PR I abandoned the shell entirely and drove the CLI from a Python wrapper just to build the arguments. `Page.captureScreenshot` returns base64 that every caller decodes by hand.

```console
$ chrome-agent eval proj-01 'document.title'
Example Domain

$ chrome-agent eval proj-01 --file probe.js       # multi-line JS, no escaping
{
  "title": "Example Domain",
  "links": 1,
  "url": "https://example.com/"
}

$ echo 'document.readyState' | chrome-agent eval proj-01 -
complete

$ chrome-agent eval proj-01 'throw new Error("boom")'
Page error: Error: boom
    at <anonymous>:1:7 (line 1)
$ echo $?
1

$ chrome-agent screenshot proj-01 -o /tmp/page.png --full-page
/tmp/page.png
$ chrome-agent screenshot proj-01 -o /tmp/h1.png --selector 'h1'
/tmp/h1.png
```

`eval` prints the **value** — string as itself, anything else as JSON — because `result.result.value` is essentially never what the caller wants; `--json` keeps the full envelope. Promises are awaited. A thrown page exception goes to stderr and exits 1, so an error can't be mistaken for a result.

`screenshot` prints the path it wrote (a human-readable line with a byte count when stdout is a TTY).

## These are wrappers, not a layer

Nothing here gates the protocol. Every verb is a thin composition of the same primitives, the raw `<instance> Domain.method` form still reaches everything, and no new schema validation is introduced — the "tracks the running browser, not its own version" property is untouched.

## Structural note

`page_ops.attached_page_session` is now the single place that resolves a page target and attaches a flattened session, and **the existing one-shot path was migrated onto it** rather than left as a parallel copy — that's most of the churn in `cli.py`, and it means every entry point shares identical target-selection and isolation semantics.

One consequence worth reviewing: `resolve_port` reaches the registry through the module (`registry.lookup`) rather than a from-import, so `test_one_shot_ambiguous_target_clean_error`, which monkeypatches `chrome_agent.registry.lookup`, keeps working unchanged.

## Testing

`190 passed` — the 162 existing tests plus 28 new ones (22 in `tests/test_page_ops.py`, 6 discovery tests in `tests/test_launcher.py`).

Two existing stubs were updated for the new `find_chrome_binary` signature (`lambda: None` → `lambda binary=None: None`) in `tests/test_launcher.py` and `tests/test_cli.py`.

New tests assert observable contracts, not plumbing: a bad `--binary` doesn't fall back; the `$PATH` fallback never displaces a system install; `eval` unwraps values, awaits promises, and raises on page exceptions; `--selector` produces an image of exactly the element's size (120×60 for a 120×60 div); `--full-page` is taller than the viewport capture; `wait` returns the event, and `None` on timeout; `navigate` reports status 200, returns `"loaded": null` for `--wait none`, and raises on a refused navigation.

Every verb was also exercised outside the suite against a real headed Chrome 151, which is where the transcripts above come from.

## Docs

`README.md` and `AGENTS.md` updated. Since `src/chrome_agent/AGENTS.md` symlinks to the root guide, `chrome-agent guide` ships the new verbs automatically. The screenshot entry in the guide's "Commands and what they return" section now points at the verb instead of the hand-rolled base64 decode one-liner.
